### PR TITLE
Find fan trays dynamically in the crate

### DIFF
--- a/python/atcaipmi/atca_root.py
+++ b/python/atcaipmi/atca_root.py
@@ -67,7 +67,7 @@ class BaseDevice(pyrogue.Device):
         d = ipmi.get_sensors(keys=keys)
         # - Add local variables for each sensor
         for n,s in d.items():
-            if not 'value' in n:
+            if not 'value' in s:
                 # If the dictionary doesn't have the 'value' field,
                 # it is a container. Expand it as a new device.
                 self.add(BaseDevice(

--- a/python/atcaipmi/monitor.py
+++ b/python/atcaipmi/monitor.py
@@ -63,10 +63,10 @@ class AtcaIpmiMonitorBase():
         # - sensor : sensor object
         # - value : sensor measurement
         self.sensors = {
-                'crate' : {
+                'Crate' : {
                     'fans' : {},
                     },
-                'slot' : {}
+                'Slots' : {}
                 }
 
     def _open_target(self, ipmb_address):
@@ -539,7 +539,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
         super().__init__(shelfmanager=shelfmanager, min_period=min_period)
 
         for i in range(2,8):
-            self.sensors['slot'][i] = {
+            self.sensors['Slots'][i] = {
                 'ID':               { 'value': ''  },
                 'Hot_Swap':         { 'type': '', 'sensor': None, 'value': 0.0 },
                 'IPMB_Physical':    { 'type': '', 'sensor': None, 'value': 0.0 },
@@ -561,8 +561,8 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
                 'AMC_2_+12V_ADIN':  { 'type': '', 'sensor': None, 'value': 0.0 },
                 'FPGA_+12V_ADIN':   { 'type': '', 'sensor': None, 'value': 0.0 },
                 'RTM_+12V_ADIN':    { 'type': '', 'sensor': None, 'value': 0.0 },
-                'amc': {},
-                'rtm': {
+                'AMCs': {},
+                'RTM': {
                     'ID':                   { 'value': '' },
                     'Product_Mfg_Name':     { 'value': '' },
                     'Product_Name':         { 'value': '' },
@@ -574,7 +574,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
             }
 
             for j in [0,2]:
-                self.sensors['slot'][i]['amc'][j] = {
+                self.sensors['Slots'][i]['AMCs'][j] = {
                     'ID':                   { 'value': '' },
                     'Product_Mfg_Name':     { 'value': '' },
                     'Product_Part_Number':  { 'value': '' },
@@ -593,7 +593,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
 
         # Scan sensor for the crate
         self._open_target(ipmb_address=0x20)
-        self._scan_sensors(['crate'])
+        self._scan_sensors(['Crate'])
 
         # Start the polling thread in the background
         self.poll_thread = threading.Thread(target = self._polling)
@@ -623,7 +623,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
 
             # Read information about the crate
             self._open_target(0x20)
-            for n,s in self.sensors['crate'].items():
+            for n,s in self.sensors['Crate'].items():
                 if n == 'fans':
                     for fn,sn in s.items():
                         fru_id = sn['speed_level']['fru_id']
@@ -644,7 +644,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
 
                 # Try to read the Carrier ID
                 id = self._read_id(slot=i, bay=4)
-                self.sensors['slot'][i]['ID']['value'] = id
+                self.sensors['Slots'][i]['ID']['value'] = id
                 if id:
                     # If a valid ID was read, read the sensors
 
@@ -653,7 +653,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
                     if self.need_search_sensors[i]:
 
                         # Search the sensor in this slot
-                        self._search_sensors(['slot', i])
+                        self._search_sensors(['Slots', i])
 
                         # We don't need to search the sensor in the next cycle
                         self.need_search_sensors[i] = False
@@ -661,23 +661,23 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
                         # Read the AMCs IDs
                         for j in [0,2]:
                             id = self._read_id(slot=i, bay=j)
-                            self.sensors['slot'][i]['amc'][j]['ID']['value'] = id
+                            self.sensors['Slots'][i]['AMCs'][j]['ID']['value'] = id
                             if id:
                                 # If valid ID is read, read the info from the EEPROM
-                                self.sensors['slot'][i]['amc'][j].update(self._read_amc_eeprom(j).copy())
+                                self.sensors['Slots'][i]['AMCs'][j].update(self._read_amc_eeprom(j).copy())
 
                         # Read the RTM ID
                         id = self._read_id(slot=i, bay=5)
-                        self.sensors['slot'][i]['rtm']['ID']['value'] = id
+                        self.sensors['Slots'][i]['RTM']['ID']['value'] = id
                         if id:
                             # If a valid ID is read, read the info from the EEPROM
-                            self.sensors['slot'][i]['rtm'].update(self._read_rtm_eeprom())
+                            self.sensors['Slots'][i]['RTM'].update(self._read_rtm_eeprom())
 
                     # Read the sensors in this carrier
-                    for n,s in self.sensors['slot'][i].items():
+                    for n,s in self.sensors['Slots'][i].items():
                         try:
-                            if n not in ['ID', 'rtm', 'amc']:
-                                self.sensors['slot'][i][n]['value'] = self._read_sensor(s)
+                            if n not in ['ID', 'RTM', 'AMCs']:
+                                self.sensors['Slots'][i][n]['value'] = self._read_sensor(s)
                         except pyipmi.errors.IpmiTimeoutError:
                             self._log.error("IPMI TImeout error when trying to read slot # {}, {}".format(i, n))
                 else:
@@ -713,12 +713,12 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
         super().__init__(shelfmanager=shelfmanager, min_period=min_period)
 
         for i in range(2,8):
-            self.sensors['slot'][i] = {}
+            self.sensors['Slots'][i] = {}
 
         # Scan sensors
         # - Sensor for the crate
         self._open_target(ipmb_address=0x20)
-        self._scan_sensors(['crate'])
+        self._scan_sensors(['Crate'])
         # - Sensors for each slot
         for i in range(2,8):
             self._open_target(ipmb_address=0x80+2*i)
@@ -727,29 +727,29 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
             id = self._read_id(slot=i, bay=4)
             if id:
                 # If a valid ID was read, add it to the sensor dict
-                self.sensors['slot'][i]['ID'] = { 'value': id }
+                self.sensors['Slots'][i]['ID'] = { 'value': id }
 
                 # Now, try to read the AMCs IDs
                 for j in [0,2]:
                     id = self._read_id(slot=i, bay=j)
                     if id:
                         # If valid IDs are read, add them to the sensor dict
-                        if 'amc' not in self.sensors['slot'][i]:
-                            self.sensors['slot'][i]['amc'] = {}
-                        self.sensors['slot'][i]['amc'][j] = {}
-                        self.sensors['slot'][i]['amc'][j]['ID'] = { 'value': id }
-                        self.sensors['slot'][i]['amc'][j].update(self._read_amc_eeprom(j))
+                        if 'AMCs' not in self.sensors['Slots'][i]:
+                            self.sensors['Slots'][i]['AMCs'] = {}
+                        self.sensors['Slots'][i]['AMCs'][j] = {}
+                        self.sensors['Slots'][i]['AMCs'][j]['ID'] = { 'value': id }
+                        self.sensors['Slots'][i]['AMCs'][j].update(self._read_amc_eeprom(j))
 
                 # Finally, try to read the RTM ID
                 id = self._read_id(slot=i, bay=5)
                 if id:
                     # If a valid ID is read, add it to the sensor list
-                    self.sensors['slot'][i]['rtm'] = {}
-                    self.sensors['slot'][i]['rtm']['ID'] = { 'value': id }
-                    self.sensors['slot'][i]['rtm'].update(self._read_rtm_eeprom())
+                    self.sensors['Slots'][i]['RTM'] = {}
+                    self.sensors['Slots'][i]['RTM']['ID'] = { 'value': id }
+                    self.sensors['Slots'][i]['RTM'].update(self._read_rtm_eeprom())
 
             # Scan for sensors
-            self._scan_sensors(['slot', i])
+            self._scan_sensors(['Slots', i])
 
         # Start the polling thread in the background
         self.poll_thread = threading.Thread(target=self._polling)
@@ -780,7 +780,7 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
 
             # Read information about the crate
             self._open_target(0x20)
-            for n,s in self.sensors['crate'].items():
+            for n,s in self.sensors['Crate'].items():
                 if n == 'fans':
                     for fn,sn in s.items():
                         fru_id = sn['speed_level']['fru_id']
@@ -799,10 +799,10 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
                 # Open a connection to the specific slot IPMC
                 self._open_target(0x80+2*i)
 
-                for n,s in self.sensors['slot'][i].items():
+                for n,s in self.sensors['Slots'][i].items():
                     try:
-                        if n not in ['ID', 'rtm', 'amc']:
-                            self.sensors['slot'][i][n]['value'] = self._read_sensor(s)
+                        if n not in ['ID', 'RTM', 'AMCs']:
+                            self.sensors['Slots'][i][n]['value'] = self._read_sensor(s)
                     except pyipmi.errors.IpmiTimeoutError:
                         self._log.error("IPMI TImeout error when trying to read slot # {}, {}".format(i, n))
 

--- a/python/atcaipmi/monitor.py
+++ b/python/atcaipmi/monitor.py
@@ -64,7 +64,7 @@ class AtcaIpmiMonitorBase():
         # - value : sensor measurement
         self.sensors = {
                 'Crate' : {
-                    'fans' : {},
+                    'FanTrays' : {},
                     },
                 'Slots' : {}
                 }
@@ -155,7 +155,7 @@ class AtcaIpmiMonitorBase():
                 elif s.type is pyipmi.sdr.SDR_TYPE_FRU_DEVICE_LOCATOR_RECORD:
                     name = ''.join("%c" % b for b in s.device_id_string).replace(" ","_")
                     if 'FanTray' in name:
-                        d['fans'][name] = {
+                        d['FanTrays'][name] = {
                                 'speed_level' : { 'fru_id': s.fru_device_id , 'value': 0 },
                                 'minimum_speed_level' : { 'value' : 0 },
                                 'maximum_speed_level' : { 'value' : 0 }
@@ -624,7 +624,7 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
             # Read information about the crate
             self._open_target(0x20)
             for n,s in self.sensors['Crate'].items():
-                if n == 'fans':
+                if n == 'FanTrays':
                     for fn,sn in s.items():
                         fru_id = sn['speed_level']['fru_id']
                         sn['speed_level']['value'] = self.ipmi.get_fan_level(fru_id)[0]
@@ -781,7 +781,7 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
             # Read information about the crate
             self._open_target(0x20)
             for n,s in self.sensors['Crate'].items():
-                if n == 'fans':
+                if n == 'FanTrays':
                     for fn,sn in s.items():
                         fru_id = sn['speed_level']['fru_id']
                         sn['speed_level']['value'] = self.ipmi.get_fan_level(fru_id)[0]

--- a/python/atcaipmi/monitor.py
+++ b/python/atcaipmi/monitor.py
@@ -631,11 +631,11 @@ class AtcaIpmiStaticMonitor(AtcaIpmiMonitorBase):
                         sn['minimum_speed_level']['value'] = self.ipmi.get_fan_speed_properties(fru_id).minimum_speed_level
                         sn['maximum_speed_level']['value'] = self.ipmi.get_fan_speed_properties(fru_id).maximum_speed_level
                 else:
-                    self.sensors['crate'][n]['value'] = self._read_sensor(s)
+                    s['value'] = self._read_sensor(s)
 
                 # Call callback function, if any
                 if 'callback' in s and s['callback'] is not None:
-                    s['callback'](value = self.sensors['crate'][n]['value'])
+                    s['callback'](value = s['value'])
 
             ## Read information of devices on each slot
             for i in range(2,8):
@@ -788,11 +788,11 @@ class AtcaIpmiDynamicMonitor(AtcaIpmiMonitorBase):
                         sn['minimum_speed_level']['value'] = self.ipmi.get_fan_speed_properties(fru_id).minimum_speed_level
                         sn['maximum_speed_level']['value'] = self.ipmi.get_fan_speed_properties(fru_id).maximum_speed_level
                 else:
-                    self.sensors['crate'][n]['value'] = self._read_sensor(s)
+                    s['value'] = self._read_sensor(s)
 
                 # Call callback function, if any
                 if 'callback' in s and s['callback'] is not None:
-                    s['callback'](value = self.sensors['crate'][n]['value'])
+                    s['callback'](value = s['value'])
 
             ## Read information of devices on each slot
             for i in range(2,8):


### PR DESCRIPTION
This PR fix the issue of fan tray's address being hardcoded, which don't work for all models of crates. Now, the fan trays are found dynamically. 

During this update, the resulting hierarchy of register changed. For example, before this PR it looked something  like this:

```
Crate.LocalSensors.Temp1
Crate.LocalSensors.FAN_3_LEVEL
Crate.Slot_2.AMC[0].ID
```

now, it looks like this instead:

```
Crate.Sensors.Crate.Temp1
Crate.Sensors.Crate.FanTrays.FanTary1.speed_level
Crate.Sensors.Slots.2.AMCs.0.ID
```
 
Details here:
https://jira.slac.stanford.edu/browse/ESCRYODET-356