### PR TITLE
Add Github workflow for generating release notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,22 @@
+# This workflow will be triggered on tags pushes and it
+# will generate release notes using green.
+
+name: Release notes
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Generate release notes
+      - name: Generate release notes
+        uses: smartlyio/github-release-notes-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.grenrc.yml
+++ b/.grenrc.yml
@@ -1,0 +1,12 @@
+---
+  dataSource: "prs"
+  onlyMilestones: false
+  # Group the release notes in three categories,
+  # based on the PR labels
+  groupBy:
+    "Bugs:":
+    - "bug"
+    "Enhancements:":
+    - "enhancement"
+  template:
+    "issue": "- {{url}} {{name}}"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The pyrogue tree is populate dynamically from the list of sensors in the crate.
 
 ## Docker image
 
-When a tag is pushed to this github repository, a new Docker image is automatically built and push to its [Dockerhub repository](https://hub.docker.com/r/tidair/smurf-atca-monitor) using travis.
+When a tag is pushed to this github repository, a new Docker image is automatically built and push to its [Dockerhub repository](https://hub.docker.com/r/tidair/smurf-atca-monitor) using GitHub Actions.
 
 The resulting docker image is tagged with the same git tag string (as returned by `git describe --tags --always`).
 


### PR DESCRIPTION
Release notes will be automatically generated when a tag is pushed, using green.

In this PR also, I remove a reference to Travis in the README file.