### PR TITLE
Add extra arguments to set port number and log level

### DIFF
--- a/atca_monitor.py
+++ b/atca_monitor.py
@@ -48,7 +48,7 @@ def get_args():
         required=False,
         default=9100,
         dest='port_number',
-        help='Rogue server port number')
+        help='Rogue server port number (default: 9100)')
 
     parser.add_argument(
         '--gui', '-g',

--- a/atca_monitor.py
+++ b/atca_monitor.py
@@ -43,6 +43,14 @@ def get_args():
              '(default: the shelfmanager node name)')
 
     parser.add_argument(
+        '--port', '-p',
+        type=int,
+        required=False,
+        defalt=9100,
+        dest='port_number',
+        help='Rogue server port number')
+
+    parser.add_argument(
         '--gui', '-g',
         action='store_true',
         dest='use_gui',
@@ -59,6 +67,7 @@ if __name__ == "__main__":
     shelfmanager = args.shelfmanager
     epics_prefix = args.epics_prefix
     use_gui = args.use_gui
+    port_number = args.port_number
 
     # Check if shelfmanager is online
     print(f"Trying to ping the shelfmanager '{shelfmanager}'...")
@@ -83,7 +92,7 @@ if __name__ == "__main__":
     ipmi = AtcaIpmiMonitor(shelfmanager=shelfmanager)
 
     # Create the ATCA crate root object
-    root = AtcaCrateRoot(ipmi=ipmi, serverPort=9100)
+    root = AtcaCrateRoot(ipmi=ipmi, serverPort=port_number)
     root.start()
 
     # Create the EPICS server

--- a/atca_monitor.py
+++ b/atca_monitor.py
@@ -15,10 +15,6 @@ from atcaipmi.monitor import AtcaIpmiStaticMonitor as AtcaIpmiMonitor
 # Import the Root, which includes a device for the while ATCA crate
 from atcaipmi.atca_root import AtcaCrateRoot
 
-# Setup the logger level to 'Error' by default
-logger = logging.getLogger('pyrogue')
-logger.setLevel(rogue.Logging.Error)
-
 
 def get_args():
     """
@@ -56,6 +52,15 @@ def get_args():
         dest='use_gui',
         help='Start the server with a GUI')
 
+    parser.add_argument(
+        '--log-level',
+        type=str,
+        required=False,
+        choices=['info', 'warning', 'error'],
+        default='error',
+        dest='log_level',
+        help='Log level (default: "error")')
+
     return parser.parse_args()
 
 
@@ -68,6 +73,7 @@ if __name__ == "__main__":
     epics_prefix = args.epics_prefix
     use_gui = args.use_gui
     port_number = args.port_number
+    log_level = args.log_level
 
     # Check if shelfmanager is online
     print(f"Trying to ping the shelfmanager '{shelfmanager}'...")
@@ -87,6 +93,15 @@ if __name__ == "__main__":
     # was defined by the user
     if not epics_prefix:
         epics_prefix = shelfmanager
+
+    # Setup the logger level. Set the 'Error' level by default
+    logger = logging.getLogger('pyrogue')
+    if log_level == 'info':
+        logger.setLevel(rogue.Logging.Info)
+    elif log_level == 'warning':
+        logger.setLevel(rogue.Logging.Warning)
+    else:
+        logger.setLevel(rogue.Logging.Error)
 
     # Start the ATCA IPMI monitor
     ipmi = AtcaIpmiMonitor(shelfmanager=shelfmanager)

--- a/atca_monitor.py
+++ b/atca_monitor.py
@@ -3,7 +3,6 @@
 import argparse
 import subprocess
 import os
-import sys
 import logging
 import rogue
 import pyrogue

--- a/atca_monitor.py
+++ b/atca_monitor.py
@@ -46,7 +46,7 @@ def get_args():
         '--port', '-p',
         type=int,
         required=False,
-        defalt=9100,
+        default=9100,
         dest='port_number',
         help='Rogue server port number')
 


### PR DESCRIPTION
This PR adds two new arguments:
- `--port`/`-p`: use to set the rogue server port number. Defaults to `9100`, and
- `--log-level'`: use to set the log level. Options are `info`, `warning`, and `error`. The default level is `error`.