### PR TITLE
Update smurf-rogue base image to version R2.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R2.7.0
+FROM tidair/smurf-rogue:R2.8.2
 
 # Install pyipmi
 RUN pip3 install python-ipmi


### PR DESCRIPTION
This updates Rogue to version [v4.11.6](https://github.com/slaclab/rogue/releases/tag/v4.11.6).